### PR TITLE
some more fixes for the tutorial

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -1,5 +1,7 @@
 # Quickstart
-To start, create create a struct and implement the ```Logic``` trait on it:
+
+To start, create create a struct and implement the `Logic` trait on it:
+
 ```rust
 use ascii_renderer::prelude::*;
 
@@ -11,9 +13,11 @@ impl Logic for MyLogic {
     }
 }
 ```
-There will be more on this later, but for now just make ```process()``` return ```ProcessReturn::Continue```.
 
-Next, create a ```Runner```, pass an instance of your logic struct to it, and run it.
+There will be more on this later, but for now just make `process()` return `ProcessReturn::Continue`.
+
+Next, create a `Runner`, pass an instance of your logic struct to it, and run it.
+
 ```rust
 use ascii_renderer::prelude::*;
 
@@ -34,11 +38,13 @@ fn main() {
     ).run(true);    //true = clears the terminal between frames
 }
 ```
-The runner will proceed to run a loop (with a maximum frequency dictated by the ```fps_cap```) where it will run it's logic's ```process()``` function, which will mutate a ```CharBuffer```, then it will print that ```CharBuffer``` to the screen, and then it will repeat if ```process()``` returned ```ProcessReturn::Continue```.
 
-The ```delta``` parameter is the amount of time (in seconds) that has passed since the last frame was drawn to the screen. It is necesary for non-frame-dependant movement.
+The runner will proceed to run a loop (with a maximum frequency dictated by the `fps_cap`) where it will run it's logic's `process()` function, which will mutate a `CharBuffer`, then it will print that `CharBuffer` to the screen, and then it will repeat if `process()` returned `ProcessReturn::Continue`.
 
-The ```CharBuffer``` can be mutated by changing individual chars (```set_char(&mut self, x, y, char)```), filling the entire buffer (```fill(&mut self, char)```), drawing lines (```draw_line(&mut self, line)```), or by rendering 3D graphics to it (more on that later). The buffer is maintained between frames, you almost always should start ```process()``` with ```screen_buf.fill(' ');```.
+The `delta` parameter is the amount of time (in seconds) that has passed since the last frame was drawn to the screen. It is necesary for non-frame-dependant movement.
+
+The `CharBuffer` can be mutated by changing individual chars (`set_char(&mut self, x, y, char)`), filling the entire buffer (`fill(&mut self, char)`), drawing lines (`draw_line(&mut self, line)`), or by rendering 3D graphics to it (more on that later). The buffer is maintained between frames, you almost always should start `process()` with `screen_buf.fill(' ');`.
+
 ```rust
 use ascii_renderer::prelude::*;
 
@@ -72,7 +78,9 @@ fn main() {
     ).run(true);    //true = clears the terminal between frames
 }
 ```
-To render 3D graphics to the ```CharBuffer```, we need to use a ```Renderer```. We don't want to instantiate a new ```Renderer``` every single frame, so we should store an instance of a ```Renderer``` wtihin a field of our logic struct. To draw graphics to the ```CharBuffer```, simply call ```draw()``` on the renderer, passing a mutable reference to the ```CharBuffer``` to it. In order to have something to render, you can create a 2x2x2 cube mesh using the ```create_cube()``` function and pass the cube to the renderer within it's declaration.
+
+To render 3D graphics to the `CharBuffer`, we need to use a `Renderer`. We don't want to instantiate a new `Renderer` every single frame, so we should store an instance of a `Renderer` wtihin a field of our logic struct. To draw graphics to the `CharBuffer`, simply call `draw()` on the renderer, passing a mutable reference to the `CharBuffer` to it. In order to have something to render, you can create a 2x2x2 cube mesh using the `create_cube()` function and pass the cube to the renderer within it's declaration.
+
 ```rust
 use ascii_renderer::prelude::*;
 
@@ -114,7 +122,9 @@ fn main() {
     ).run(true);    //true = clears the terminal between frames
 }
 ```
-For any values that need to be consistent, more fields can be added to the logic struct. For example, this logic contains a field that keeps track of how much time (in seconds) has passed since the runner started, and ```process()``` feeds that value into a sin function which determines the cube's scale in each dimension, creating a cool looking effect (as shown in [this](https://youtu.be/faViJzniUQA) video):
+
+For any values that need to be consistent, more fields can be added to the logic struct. For example, this logic contains a field that keeps track of how much time (in seconds) has passed since the runner started, and `process()` feeds that value into a sin function which determines the cube's scale in each dimension, creating a cool looking effect (as shown in [this](https://youtu.be/faViJzniUQA) video):
+
 ```rust
 use ascii_renderer::prelude::*;
 
@@ -162,7 +172,9 @@ fn main() {
     runner.run(true);
 }
 ```
-Finally, to load meshes from file (currently only .OBJ is supported), run the function ```AsciiObj::load(path)```, which will return a ```Result<AsciiObj, ObjError>```. After ```unwrap()```ing it, the ```AsciiObj``` can be converted into a ```Vec<Mesh>``` using ```into()```, which all together would look like ```let my_meshes: Vec<Mesh> = AsciiObj::load("face.obj").unwrap().into();```. However, often times meshes are far from the origin, causing the mesh to appear to spin in a large circle centered around the origin rather than rotate around a point when rotated. Because of that, allways run the ```recenter()``` method on the mesh before passing it to the renderer. ```recenter()``` returns the position the mesh was originally centered at, if you wish to maintain it's in-file position. This example demonstrates overall how to load objs:
+
+Finally, to load meshes from file (currently only .OBJ is supported), run the function `AsciiObj::load(path)`, which will return a `Result<AsciiObj, ObjError>`. After `unwrap()`ing it, the `AsciiObj` can be converted into a `Vec<Mesh>` using `into()`, which all together would look like `let my_meshes: Vec<Mesh> = AsciiObj::load("face.obj").unwrap().into();`. However, often times meshes are far from the origin, causing the mesh to appear to spin in a large circle centered around the origin rather than rotate around a point when rotated. Because of that, allways run the `recenter()` method on the mesh before passing it to the renderer. `recenter()` returns the position the mesh was originally centered at, if you wish to maintain it's in-file position. This example demonstrates overall how to load objs:
+
 ```rust
 use ascii_renderer::prelude::*;
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -92,8 +92,9 @@ impl Logic for MyLogic {
     fn process(&mut self, screen_buf: &mut CharBuffer, delta: f32) -> ProcessReturn {
         screen_buf.fill(' ');
 
-        let fps_string: String = (1.0 / delta).into();
-        let mut fps_chars = fps.chars();
+        // FIXME: i think this could be left out entirely
+        let fps_string = (1.0 / delta).to_string();
+        let mut fps_chars = fps_string.chars();
 
         self.renderer.draw(screen_buf);
 


### PR DESCRIPTION
i edited the tutorial page to conform with the markdown guidlines:
- [markdown lint tool](https://github.com/DavidAnson/markdownlint/tree/d01180ec5a014083ee9d574b693a8d7fbc1e566d/doc)
- [markdown rfc](https://www.rfc-editor.org/rfc/rfc7763)

another thing that should be looked at is [these lines](https://github.com/EvanCMcPheron/ascii_renderer/blob/798c8c2ff1dad4f7793506bf0071ff97ed52b5bc/tutorial.md?plain=1#L95) since the fps counter could be removed.